### PR TITLE
Add an option to specify initial output values

### DIFF
--- a/fbsat-cli/src/main/kotlin/ru/ifmo/fbsat/cli/Main.kt
+++ b/fbsat-cli/src/main/kotlin/ru/ifmo/fbsat/cli/Main.kt
@@ -372,9 +372,6 @@ class FbSAT : CliktCommand() {
         Globals.IS_ENCODE_DISJUNCTIVE_TRANSITIONS = isEncodeDisjunctiveTransitions
         Globals.IS_REUSE_K = isReuseK
         Globals.IS_DEBUG = isDebug
-        Globals.INITIAL_OUTPUT_VALUES = initialOutputValues?.let {
-            OutputValues(it.map { c -> c == '1' }.toList())
-        }
 
         // outDir.deleteRecursively()
         // outDir.walkBottomUp().forEach { if (it != outDir) it.delete() }
@@ -385,6 +382,11 @@ class FbSAT : CliktCommand() {
         val outputNames = fileOutputNames?.readLines() ?: outputNamesPnP
         log.info("Input names: $inputNames")
         log.info("Output names: $outputNames")
+
+        Globals.INITIAL_OUTPUT_VALUES = if (initialOutputValues != null)
+            OutputValues(initialOutputValues!!.map { c -> c == '1' }.toList())
+        else
+            OutputValues.zeros(outputNames.size)
 
         val tree = ScenarioTree.fromFile(fileScenarios, inputNames, outputNames)
         log.info("Scenarios: ${tree.scenarios.size}")

--- a/fbsat-core/src/main/kotlin/ru/ifmo/fbsat/core/automaton/Algorithm.kt
+++ b/fbsat-core/src/main/kotlin/ru/ifmo/fbsat/core/automaton/Algorithm.kt
@@ -11,6 +11,8 @@ class BinaryAlgorithm(val algorithm0: BooleanArray, val algorithm1: BooleanArray
     constructor(algorithm0: Collection<Boolean>, algorithm1: Collection<Boolean>) :
         this(algorithm0.toBooleanArray(), algorithm1.toBooleanArray())
 
+    constructor(anyway: BooleanArray): this(anyway, anyway)
+
     init {
         require(algorithm0.size == algorithm1.size) {
             "Algorithm size mismatch (algo0 = $algorithm0, algo1 = $algorithm1)"

--- a/fbsat-core/src/main/kotlin/ru/ifmo/fbsat/core/automaton/Automaton.kt
+++ b/fbsat-core/src/main/kotlin/ru/ifmo/fbsat/core/automaton/Automaton.kt
@@ -228,20 +228,17 @@ class Automaton(
     ): EvalResult =
         state.eval(inputAction, values)
 
-    private fun outputValues() =
-        Globals.INITIAL_OUTPUT_VALUES ?: OutputValues.zeros(outputNames.size)
-
     fun eval(
         inputActions: Iterable<InputAction>,
         startState: State = initialState,
-        startValues: OutputValues = outputValues()
+        startValues: OutputValues = Globals.INITIAL_OUTPUT_VALUES
     ): List<EvalResult> =
         eval(inputActions.asSequence(), startState, startValues).toList()
 
     fun eval(
         inputActions: Sequence<InputAction>,
         startState: State = initialState,
-        startValues: OutputValues = outputValues()
+        startValues: OutputValues = Globals.INITIAL_OUTPUT_VALUES
     ): Sequence<EvalResult> {
         var currentState = startState
         var currentValues = startValues

--- a/fbsat-core/src/main/kotlin/ru/ifmo/fbsat/core/automaton/Automaton.kt
+++ b/fbsat-core/src/main/kotlin/ru/ifmo/fbsat/core/automaton/Automaton.kt
@@ -12,11 +12,7 @@ import ru.ifmo.fbsat.core.scenario.negative.NegativeScenario
 import ru.ifmo.fbsat.core.scenario.negative.NegativeScenarioTree
 import ru.ifmo.fbsat.core.scenario.positive.PositiveScenario
 import ru.ifmo.fbsat.core.scenario.positive.ScenarioTree
-import ru.ifmo.fbsat.core.utils.Globals
-import ru.ifmo.fbsat.core.utils.graph
-import ru.ifmo.fbsat.core.utils.log
-import ru.ifmo.fbsat.core.utils.mutableListOfNulls
-import ru.ifmo.fbsat.core.utils.random
+import ru.ifmo.fbsat.core.utils.*
 import java.io.File
 
 class Automaton(
@@ -232,17 +228,20 @@ class Automaton(
     ): EvalResult =
         state.eval(inputAction, values)
 
+    private fun outputValues() =
+        Globals.INITIAL_OUTPUT_VALUES ?: OutputValues.zeros(outputNames.size)
+
     fun eval(
         inputActions: Iterable<InputAction>,
         startState: State = initialState,
-        startValues: OutputValues = OutputValues.zeros(outputNames.size)
+        startValues: OutputValues = outputValues()
     ): List<EvalResult> =
         eval(inputActions.asSequence(), startState, startValues).toList()
 
     fun eval(
         inputActions: Sequence<InputAction>,
         startState: State = initialState,
-        startValues: OutputValues = OutputValues.zeros(outputNames.size)
+        startValues: OutputValues = outputValues()
     ): Sequence<EvalResult> {
         var currentState = startState
         var currentValues = startValues
@@ -556,8 +555,7 @@ class Automaton(
                     // Note: INIT algorithm zeroes out all variables
                     "ST"(
                         "Text" to BinaryAlgorithm(
-                            BooleanArray(Z) { false },
-                            BooleanArray(Z) { false }
+                            Globals.INITIAL_OUTPUT_VALUES?.getArray() ?: BooleanArray(Z) { false }
                         ).toST(outputNames)
                     )
                 }

--- a/fbsat-core/src/main/kotlin/ru/ifmo/fbsat/core/automaton/Interface.kt
+++ b/fbsat-core/src/main/kotlin/ru/ifmo/fbsat/core/automaton/Interface.kt
@@ -44,9 +44,14 @@ inline class InputValues(val values: List<Boolean>) {
 }
 
 inline class OutputValues(val values: List<Boolean>) {
+    val size: Int
+        get() = values.size
+
     operator fun get(index: Int): Boolean {
         return values[index]
     }
+
+    fun getArray() = values.toBooleanArray()
 
     // override fun toString(): String {
     //     return values.toString()

--- a/fbsat-core/src/main/kotlin/ru/ifmo/fbsat/core/constraints/ArbitraryModularAutomatonStructureConstraints.kt
+++ b/fbsat-core/src/main/kotlin/ru/ifmo/fbsat/core/constraints/ArbitraryModularAutomatonStructureConstraints.kt
@@ -1,13 +1,6 @@
 package ru.ifmo.fbsat.core.constraints
 
-import ru.ifmo.fbsat.core.solver.BoolVarArray
-import ru.ifmo.fbsat.core.solver.IntVarArray
-import ru.ifmo.fbsat.core.solver.Solver
-import ru.ifmo.fbsat.core.solver.clause
-import ru.ifmo.fbsat.core.solver.iff
-import ru.ifmo.fbsat.core.solver.iffAnd
-import ru.ifmo.fbsat.core.solver.iffOr
-import ru.ifmo.fbsat.core.solver.imply
+import ru.ifmo.fbsat.core.solver.*
 import ru.ifmo.fbsat.core.task.modular.basic.arbitrary.ArbitraryModularBasicVariables
 import ru.ifmo.fbsat.core.utils.EpsilonOutputEvents
 import ru.ifmo.fbsat.core.utils.Globals
@@ -78,6 +71,26 @@ private fun Solver.declareModuleAutomatonStructureConstraints(
         }
         StartStateAlgorithms.ANY -> {
             comment("Start state algorithms may be arbitrary")
+        }
+        StartStateAlgorithms.INIT -> {
+            comment("Start state does the same as init state")
+            for (z in 1..Z) {
+                val initVal = Globals.INITIAL_OUTPUT_VALUES!![z - 1]
+                val botLiteral = stateAlgorithmBot[1, z]
+                val topLiteral = stateAlgorithmTop[1, z]
+                clause(if (initVal) botLiteral else -botLiteral)
+                clause(if (initVal) topLiteral else -topLiteral)
+            }
+        }
+        StartStateAlgorithms.INITNOTHING -> {
+            comment("Start state does not change initial values")
+            for (z in 1..Z) {
+                val initVal = Globals.INITIAL_OUTPUT_VALUES!![z - 1]
+                if (initVal)
+                    clause(stateAlgorithmTop[1, z])
+                else
+                    clause(-stateAlgorithmBot[1, z])
+            }
         }
     }.exhaustive
 

--- a/fbsat-core/src/main/kotlin/ru/ifmo/fbsat/core/constraints/AutomatonStructureConstraints.kt
+++ b/fbsat-core/src/main/kotlin/ru/ifmo/fbsat/core/constraints/AutomatonStructureConstraints.kt
@@ -1,16 +1,6 @@
 package ru.ifmo.fbsat.core.constraints
 
-import ru.ifmo.fbsat.core.solver.BoolVarArray
-import ru.ifmo.fbsat.core.solver.IntVarArray
-import ru.ifmo.fbsat.core.solver.Solver
-import ru.ifmo.fbsat.core.solver.atLeastOne
-import ru.ifmo.fbsat.core.solver.atMostOne
-import ru.ifmo.fbsat.core.solver.clause
-import ru.ifmo.fbsat.core.solver.exactlyOne
-import ru.ifmo.fbsat.core.solver.iff
-import ru.ifmo.fbsat.core.solver.iffAnd
-import ru.ifmo.fbsat.core.solver.iffOr
-import ru.ifmo.fbsat.core.solver.imply
+import ru.ifmo.fbsat.core.solver.*
 import ru.ifmo.fbsat.core.task.modular.basic.consecutive.ConsecutiveModularBasicVariables
 import ru.ifmo.fbsat.core.task.modular.basic.parallel.ParallelModularBasicVariables
 import ru.ifmo.fbsat.core.task.single.basic.BasicVariables
@@ -203,6 +193,26 @@ private fun Solver.declareAutomatonStructureConstraintsInputless(
         }
         StartStateAlgorithms.ANY -> {
             comment("Start state algorithms may be arbitrary")
+        }
+        StartStateAlgorithms.INIT -> {
+            comment("Start state algorithms are the same as init state algorithms")
+            for (z in 1..Z) {
+                val initVal = Globals.INITIAL_OUTPUT_VALUES!![z - 1]
+                val botLiteral = stateAlgorithmBot[1, z]
+                val topLiteral = stateAlgorithmTop[1, z]
+                clause(if (initVal) botLiteral else -botLiteral)
+                clause(if (initVal) topLiteral else -topLiteral)
+            }
+        }
+        StartStateAlgorithms.INITNOTHING -> {
+            comment("Start state does not change initial values")
+            for (z in 1..Z) {
+                val initVal = Globals.INITIAL_OUTPUT_VALUES!![z - 1]
+                if (initVal)
+                    clause(stateAlgorithmTop[1, z])
+                else
+                    clause(-stateAlgorithmBot[1, z])
+            }
         }
     }.exhaustive
 

--- a/fbsat-core/src/main/kotlin/ru/ifmo/fbsat/core/scenario/positive/PositiveScenario.kt
+++ b/fbsat-core/src/main/kotlin/ru/ifmo/fbsat/core/scenario/positive/PositiveScenario.kt
@@ -43,7 +43,6 @@ data class PositiveScenario(
 
         fun fromString(s: String, preprocess: Boolean = true): PositiveScenario {
             var lastOutputValues = Globals.INITIAL_OUTPUT_VALUES
-                ?: OutputValues.zeros(regexOutputValues.find(s)!!.groups[1]!!.value.length)
             val elements: List<ScenarioElement> = s
                 .splitToSequence(";")
                 .map { it.trim() }

--- a/fbsat-core/src/main/kotlin/ru/ifmo/fbsat/core/scenario/positive/PositiveScenario.kt
+++ b/fbsat-core/src/main/kotlin/ru/ifmo/fbsat/core/scenario/positive/PositiveScenario.kt
@@ -4,15 +4,8 @@ import ru.ifmo.fbsat.core.automaton.InputEvent
 import ru.ifmo.fbsat.core.automaton.InputValues
 import ru.ifmo.fbsat.core.automaton.OutputEvent
 import ru.ifmo.fbsat.core.automaton.OutputValues
-import ru.ifmo.fbsat.core.scenario.InputAction
-import ru.ifmo.fbsat.core.scenario.OutputAction
-import ru.ifmo.fbsat.core.scenario.Scenario
-import ru.ifmo.fbsat.core.scenario.ScenarioElement
-import ru.ifmo.fbsat.core.scenario.preprocessed
-import ru.ifmo.fbsat.core.utils.log
-import ru.ifmo.fbsat.core.utils.sourceAutoGzip
-import ru.ifmo.fbsat.core.utils.toBooleanList
-import ru.ifmo.fbsat.core.utils.useLines
+import ru.ifmo.fbsat.core.scenario.*
+import ru.ifmo.fbsat.core.utils.*
 import java.io.File
 
 data class PositiveScenario(
@@ -49,7 +42,8 @@ data class PositiveScenario(
         }
 
         fun fromString(s: String, preprocess: Boolean = true): PositiveScenario {
-            var lastOutputValues = OutputValues.zeros(regexOutputValues.find(s)!!.groups[1]!!.value.length)
+            var lastOutputValues = Globals.INITIAL_OUTPUT_VALUES
+                ?: OutputValues.zeros(regexOutputValues.find(s)!!.groups[1]!!.value.length)
             val elements: List<ScenarioElement> = s
                 .splitToSequence(";")
                 .map { it.trim() }

--- a/fbsat-core/src/main/kotlin/ru/ifmo/fbsat/core/scenario/positive/ScenarioTree.kt
+++ b/fbsat-core/src/main/kotlin/ru/ifmo/fbsat/core/scenario/positive/ScenarioTree.kt
@@ -124,7 +124,7 @@ class ScenarioTree(
                 OutputAction(
                     event = null,
                     // event = OutputEvent("INITO"),
-                    values = Globals.INITIAL_OUTPUT_VALUES ?: OutputValues.zeros(outputNames.size)
+                    values = Globals.INITIAL_OUTPUT_VALUES
                 )
             ),
             parent = null

--- a/fbsat-core/src/main/kotlin/ru/ifmo/fbsat/core/scenario/positive/ScenarioTree.kt
+++ b/fbsat-core/src/main/kotlin/ru/ifmo/fbsat/core/scenario/positive/ScenarioTree.kt
@@ -11,6 +11,7 @@ import ru.ifmo.fbsat.core.scenario.InputAction
 import ru.ifmo.fbsat.core.scenario.OutputAction
 import ru.ifmo.fbsat.core.scenario.ScenarioElement
 import ru.ifmo.fbsat.core.scenario.ScenarioTreeInterface
+import ru.ifmo.fbsat.core.utils.Globals
 import ru.ifmo.fbsat.core.utils.toBinaryString
 import java.io.File
 
@@ -123,7 +124,7 @@ class ScenarioTree(
                 OutputAction(
                     event = null,
                     // event = OutputEvent("INITO"),
-                    values = OutputValues.zeros(scenario.elements.first().outputValues.values.size)
+                    values = Globals.INITIAL_OUTPUT_VALUES ?: OutputValues.zeros(outputNames.size)
                 )
             ),
             parent = null

--- a/fbsat-core/src/main/kotlin/ru/ifmo/fbsat/core/utils/Globals.kt
+++ b/fbsat-core/src/main/kotlin/ru/ifmo/fbsat/core/utils/Globals.kt
@@ -1,6 +1,7 @@
 package ru.ifmo.fbsat.core.utils
 
 import org.redundent.kotlin.xml.PrintOptions
+import ru.ifmo.fbsat.core.automaton.OutputValues
 import ru.ifmo.fbsat.core.solver.VarEncoding
 
 enum class SolverBackend {
@@ -12,10 +13,11 @@ enum class EpsilonOutputEvents {
 }
 
 enum class StartStateAlgorithms {
-    NOTHING, ZERO, ZERONOTHING, ANY;
+    NOTHING, ZERO, ZERONOTHING, ANY, INIT, INITNOTHING;
 }
 
 object Globals {
+    var INITIAL_OUTPUT_VALUES: OutputValues? = null
     var EPSILON_OUTPUT_EVENTS: EpsilonOutputEvents = EpsilonOutputEvents.ONLYSTART
     var START_STATE_ALGORITHMS: StartStateAlgorithms = StartStateAlgorithms.ZERO
     var IS_FORBID_OR: Boolean = false

--- a/fbsat-core/src/main/kotlin/ru/ifmo/fbsat/core/utils/Globals.kt
+++ b/fbsat-core/src/main/kotlin/ru/ifmo/fbsat/core/utils/Globals.kt
@@ -3,6 +3,7 @@ package ru.ifmo.fbsat.core.utils
 import org.redundent.kotlin.xml.PrintOptions
 import ru.ifmo.fbsat.core.automaton.OutputValues
 import ru.ifmo.fbsat.core.solver.VarEncoding
+import kotlin.properties.Delegates
 
 enum class SolverBackend {
     DEFAULT, INCREMENTAL, FILE, MINISAT, CADICAL;
@@ -17,7 +18,7 @@ enum class StartStateAlgorithms {
 }
 
 object Globals {
-    var INITIAL_OUTPUT_VALUES: OutputValues? = null
+    var INITIAL_OUTPUT_VALUES: OutputValues by Delegates.notNull()
     var EPSILON_OUTPUT_EVENTS: EpsilonOutputEvents = EpsilonOutputEvents.ONLYSTART
     var START_STATE_ALGORITHMS: StartStateAlgorithms = StartStateAlgorithms.ZERO
     var IS_FORBID_OR: Boolean = false


### PR DESCRIPTION
Add an option `--initial-output-values` to specify initial output values.
Add more options for start state algorithms constraints:
- `init` assigns initial values to output variables in the start state,
- `initnothing` does not change output variables if their values are equal to initial values.